### PR TITLE
#32 サービス遅延問題に関する本対応

### DIFF
--- a/src/main/java/jp/co/nissho_ele/handson/controller/AddressController.java
+++ b/src/main/java/jp/co/nissho_ele/handson/controller/AddressController.java
@@ -37,8 +37,8 @@ public class AddressController {
     @Produces(MediaType.APPLICATION_JSON)
     public List<String> postalCode(@PathParam String code) {
 
-        // var addressList = service.getAddressName(code);
-        var addressList = service.getAddressNameNoCache(code);
+        var addressList = service.getAddressName(code);
+        // var addressList = service.getAddressNameNoCache(code);
         if (addressList == null) {
             throw new RuntimeException();
         }


### PR DESCRIPTION
データベースの呼び出しにおいて
キャッシュ情報を使用せずに直接Queryを呼び出していたので
ORMキャッシュを利用するように修正します。