### PR TITLE
ORMのキャッシュ機能有効化によるパフォーマンス改善

### DIFF
--- a/src/main/java/jp/co/nissho_ele/handson/controller/AddressController.java
+++ b/src/main/java/jp/co/nissho_ele/handson/controller/AddressController.java
@@ -37,8 +37,8 @@ public class AddressController {
     @Produces(MediaType.APPLICATION_JSON)
     public List<String> postalCode(@PathParam String code) {
 
-        // var addressList = service.getAddressName(code);
-        var addressList = service.getAddressNameNoCache(code);
+        var addressList = service.getAddressName(code);
+        // var addressList = service.getAddressNameNoCache(code);
         if (addressList == null) {
             throw new RuntimeException();
         }


### PR DESCRIPTION
ユーザー集中により、アプリケーションの負荷増大時、DBクエリが極端に遅くなる。
パフォーマンスを改善するためにORMのキャッシュを有効にする。